### PR TITLE
Fix repeated nidr_parse_error by resetting error counters

### DIFF
--- a/nidr/nidr.c
+++ b/nidr/nidr.c
@@ -2473,7 +2473,14 @@ nidr_cleanup(void)
 		}
 	if (AVLT)
 		AVL_Clear();
-	return nidr_parse_error();
+
+    const int ec = nidr_parse_error();
+    if (ec) {
+        nsquawk = 0;
+        nparse_errors = 0;
+    }
+
+    return ec;
 	}
 
  void


### PR DESCRIPTION
### Problem:
When nidr_parse_error() returns an error, internal counters `nsquawk`
and `nparse_errors` are not reset. This causes the function to keep
returning an error on subsequent calls, even if no new parsing error
has occurred.

### Fix:
Set `nsquawk = 0` and `nparse_errors = 0` immediately after a
non-zero return from `nidr_parse_error()`. This clears the error
state so that future calls return correctly unless a new error
actually occurs.

### Impact:
- Fixes persistent error return behavior after a single parsing error
- No changes to behavior when no parsing errors occur