### PR TITLE
Fixes for vanshanno

### DIFF
--- a/OPTPP/src/Newton/OptNIPSLike.C
+++ b/OPTPP/src/Newton/OptNIPSLike.C
@@ -1036,7 +1036,7 @@ void OptNIPSLike::updateMu(int k)
         }
      }
      else if(mfcn == VanShanno){
-        min_sz    = s(1)*z(1);
+        min_sz    = s(0)*z(0);
         for(i = 0; i < mi; i++)
             min_sz  = min(min_sz, s(i)*z(i));
         t3        = dotprod/mi; 
@@ -1264,11 +1264,12 @@ double OptNIPSLike::merit3(int flag, const SerialDenseVector<int,double>& xc,
       conresid.resize(nlp->getConstraints()->getNumOfCons());
       conresid  = nlp->getConstraints()->evalResidual(xc);
     }
-    else
+    else {
       conresid.resize(getConstraintResidual().length());
       conresid = getConstraintResidual();
+    }
 
-     for(i = 1; i <= mi; i++){
+     for(i = 0; i < mi; i++){
         t2     = max(tiny,sc(i));
         sumlog =  sumlog + log(t2);
         conresid(me+i) -= sc(i);


### PR DESCRIPTION
Using gcc's memory sanitizer I found two off by one buffer over-read errors when running QNIPS with Vanderbei-Shanno merit function.
There is also a bug in how conresid is set due to missing curly brackets